### PR TITLE
Support string literals using backticks (`) and single quotes (')

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -61,7 +61,13 @@ function escapeJson() {
 
 function unEscapeJson() {
   try {
-    const obj = JSON.parse(text.value);
+    let str = text.value;
+    if (str && (/^ ?`.*?` ?$/.test(str) || /^ ?'.*?' ?$/.test(str))) {
+      str = eval(`let x = ${str}\nx`);
+      codeMirror.value?.setValue(JSON.stringify(JSON.parse(str)));
+      return;
+    }
+    const obj = JSON.parse(str);
     if (typeof obj === "string") {
       codeMirror.value?.setValue(obj);
     }


### PR DESCRIPTION
Support string literals using backticks () and single quotes ('), e.g., example` and 'example'.
